### PR TITLE
Support VSD-branded Stream Dock M18 (0x5548:0x1000)

### DIFF
--- a/Python-SDK/99-streamdock.rules
+++ b/Python-SDK/99-streamdock.rules
@@ -44,6 +44,8 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="1020", MODE="0666", 
 # StreamDock Mini series
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="1036", MODE="0666", GROUP="plugdev"
 SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="1037", MODE="0666", GROUP="plugdev"
+# VSD / VSDinside-branded Stream Dock M18
+SUBSYSTEM=="usb", ATTR{idVendor}=="5548", ATTR{idProduct}=="1000", MODE="0666", GROUP="plugdev"
 
 # StreamDock K1Pro series
 SUBSYSTEM=="usb", ATTR{idVendor}=="6603", ATTR{idProduct}=="1015", MODE="0666", GROUP="plugdev"

--- a/Python-SDK/src/StreamDock/ProductIDs.py
+++ b/Python-SDK/src/StreamDock/ProductIDs.py
@@ -35,6 +35,8 @@ class USBVendorIDs:
     USB_VID_K1_PROEU = 0x6603
     USB_VID_Mini = 0x5548
     USB_VID_MiniW = 0x5548
+    # VSD / VSDinside-branded Stream Dock M18
+    USB_VID_VSD_M18 = 0x5548
 
 
 class USBProductIDs:
@@ -76,6 +78,7 @@ class USBProductIDs:
     USB_PID_K1_PROEU = 0x1019
     USB_PID_Mini = 0x1036
     USB_PID_MiniW = 0x1037
+    USB_PID_VSD_M18 = 0x1000
 
 
 from .Devices.StreamDock293 import StreamDock293
@@ -151,6 +154,8 @@ g_products = [
     # M18/M18V2/M18V25/M18V3
     (USBVendorIDs.USB_VID_M18, USBProductIDs.USB_PID_STREAMDOCK_M18, StreamDockM18),
     (USBVendorIDs.USB_VID_M18EN, USBProductIDs.USB_PID_STREAMDOCK_M18EN, StreamDockM18),
+    # VSD-branded M18: same hardware, VID 0x5548 / PID 0x1000
+    (USBVendorIDs.USB_VID_VSD_M18, USBProductIDs.USB_PID_VSD_M18, StreamDockM18),
     # (USBVendorIDs.USB_VID_M18V2, USBProductIDs.USB_PID_STREAMDOCK_M18V2, StreamDockM18),
     # (USBVendorIDs.USB_VID_M18V2EN, USBProductIDs.USB_PID_STREAMDOCK_M18V2EN, StreamDockM18),
     # (USBVendorIDs.USB_VID_M18V25, USBProductIDs.USB_PID_STREAMDOCK_M18V25, StreamDockM18),


### PR DESCRIPTION
The VSDinside/VSD **Stream Dock M18** is the same hardware as the M18 already supported here, but ships behind **VID `0x5548` / PID `0x1000`** instead of the `0x6603` / `0x1009`|`0x1012` pairs currently in `g_products`.

It enumerates as `HOTSPOTEKUSB HID DEMO` and has **15 LCD keys + 3 physical buttons**, matching `StreamDockM18.KEY_COUNT = 15`.

### Verified on Ubuntu 24.04.4 (x86_64, kernel 6.8.0-136)

The bundled C transport library already speaks to this device **unmodified** — only the `g_products` filter rejected it:

```
# before this patch
transport.enumerate_devices(0x5548, 0x1000)
  -> {"path": "/dev/hidraw2", "vendor_id": 21832, "product_id": 4096,
      "serial_number": "81D0DA78532E", "manufacturer_string": "HOTSPOTEKUSB",
      "product_string": "HOTSPOTEKUSB HID DEMO", "interface_number": 0}
DeviceManager().enumerate()  -> 0 devices

# after this patch
DeviceManager().enumerate()  -> 1 device
  class=StreamDockM18  path=/dev/hidraw2  KEY_COUNT=15
  open() -> success
```

### Changes

- `Python-SDK/src/StreamDock/ProductIDs.py` — add `USB_VID_VSD_M18` / `USB_PID_VSD_M18` and the `g_products` entry mapping them to `StreamDockM18`
- `Python-SDK/99-streamdock.rules` — add the matching explicit rule for consistency (the VID-wide `hidraw` rule already covered this device in practice)

No behaviour change for any existing device.